### PR TITLE
Fix main content shift when drawers open

### DIFF
--- a/app.css
+++ b/app.css
@@ -155,13 +155,7 @@ body.light input, body.light select, body.light textarea{ background:#fff; color
 
 /* === 2) If the calendar overlaps, give main content enough right margin === */
 :root{ --drawerW: 380px; }              /* fallback; JS will set the real width */
-/* NEW: always reserve space when a drawer is pinned (desktop) */
-@media (min-width: 761px){
-  body.drawer-pinned #app{
-    margin-right: calc(var(--drawerW, 380px) + 12px);
-    transition: margin-right .2s ease;
-  }
-}
+/* Margin is now applied only when overlap is detected via JS (body.drawer-overlap) */
 
 
 /* =================== BUTTONS =================== */
@@ -663,13 +657,7 @@ body.light input[type="checkbox"]:checked{
 }
 #calendarDrawer .card .bd, #namesDrawer .card .bd{ overflow: auto; }
 
-/* Pinned layout: reserve only the open drawer + rail */
-body.drawer-cal-pinned   #app{
-  margin-right: calc(min(var(--cal-drawer-w), 92vw) + var(--rail-w));
-}
-body.drawer-names-pinned #app{
-  margin-right: calc(min(var(--names-drawer-w), 92vw) + var(--rail-w));
-}
+/* (Removed pinned layout spacing; margin is only added on overlap) */
 
 /* Stacking: header over drawers/rail; modals over everything */
 header{ z-index: 10050 !important; }
@@ -822,5 +810,4 @@ body.drawer-overlap #app { margin-right: var(--drawerW); }
 @media (max-width: 900px){
   body.drawer-overlap #app { margin-right: 0; }
 }
-
-#app { margin-right: 0; }
+/* Default state: centered via .wrap margin */

--- a/app.js
+++ b/app.js
@@ -69,12 +69,7 @@ function findCustomersCard(){
   }
   return null;
 }
-function rectsOverlap(a,b){
-  if (!a || !b) return false;
-  return !(a.right <= b.left || a.left >= b.right || a.bottom <= b.top || a.top >= b.bottom);
-}
-
-// 2) treat PINNED drawer as always needing space
+// Measure the open drawer and add right margin only if it overlaps content
 function updateDrawerOverlap(){
   const drawer = ['calendarDrawer','namesDrawer']
     .map(id => document.getElementById(id))


### PR DESCRIPTION
## Summary
- Remove pinned drawer spacing so the page stays centered by default
- Only add right margin when an open drawer overlaps the main content
- Drop unused helper and clarify drawer-overlap measurement

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9d72482308326aca5816c25ff1b33