### PR TITLE
Center app when right-side tools open

### DIFF
--- a/app.css
+++ b/app.css
@@ -815,11 +815,14 @@ body.light #namesList .name-pill.used{
 /* When a drawer overlaps, shrink the main app width and reserve space to the right */
 body.drawer-overlap #app {
   width: calc(100% - var(--drawerW));
-  margin-right: var(--drawerW);
+  max-width: var(--page-max);
+  margin-left: var(--drawerPad);
+  margin-right: calc(var(--drawerW) + var(--drawerPad));
 }
 @media (max-width: 900px){
   body.drawer-overlap #app {
     width: 100%;
+    margin-left: 0;
     margin-right: 0;
   }
 }

--- a/app.js
+++ b/app.js
@@ -70,6 +70,7 @@ function updateDrawerOverlap(){
   if (!panel){
     document.body.classList.remove('drawer-overlap');
     document.body.style.removeProperty('--drawerW');
+    document.body.style.removeProperty('--drawerPad');
     return;
   }
 
@@ -78,8 +79,16 @@ function updateDrawerOverlap(){
     .getPropertyValue('--rail-w')) || 0;
   const space = panel.getBoundingClientRect().width + railW;
 
+  // figure out how much horizontal room is left for the main content
+  const pageMax = parseFloat(getComputedStyle(document.documentElement)
+    .getPropertyValue('--page-max')) || 0;
+  const avail = window.innerWidth - space;          // space left after drawer
+  const content = Math.min(avail, pageMax);         // actual content width
+  const pad = Math.max((avail - content) / 2, 0);   // leftover space to center
+
   document.body.classList.add('drawer-overlap');
   document.body.style.setProperty('--drawerW', space + 'px');
+  document.body.style.setProperty('--drawerPad', pad + 'px');
 }
 
 


### PR DESCRIPTION
## Summary
- Compute remaining viewport space when a drawer opens and center the main content within it
- Adjust styles to reserve drawer space without shifting the agenda and customers panels off-center

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1b4df01083269acd3d548fbe77e7