### PR TITLE
Animate manual task popover and ensure overlay covers header

### DIFF
--- a/app.css
+++ b/app.css
@@ -493,10 +493,11 @@ body.light .ovr-list li{ background:#fff }
 }
 #customTaskPop{
   position:fixed; inset:0; display:none; align-items:center; justify-content:center;
-  background:rgba(0,0,0,.55); backdrop-filter:blur(6px); z-index:9999; padding:18px;
+  background:rgba(0,0,0,.55); backdrop-filter:blur(6px); z-index:11000; padding:18px;
 }
 #customTaskPop .sheet{
   width:min(560px,92vw); background:var(--panel); border:1px solid var(--line); border-radius:12px; padding:12px; box-shadow:var(--sh-2);
+  animation:pop .16s ease-out;
 }
 /* Client wider than Type */
 #customTaskPop .row { grid-template-columns: 2fr 1fr; }

--- a/app.js
+++ b/app.js
@@ -2450,6 +2450,7 @@ if (clientForm) {
       $('#ctNotify').disabled = !$('#ctTime').value;
 
       pop.style.display = 'flex';   // overlay
+      document.body.classList.add('modal-open');
       // ✨ Keyboard: Esc closes, Enter saves (except in Notes)
       pop._keydown = (e)=>{
         if(e.key==='Escape'){ e.preventDefault(); closeCustomTaskPopover(); }
@@ -2480,6 +2481,7 @@ if (clientForm) {
     if(pop._keydown){ document.removeEventListener('keydown', pop._keydown); pop._keydown=null; }
     if(pop._backdrop){ pop.removeEventListener('click', pop._backdrop); pop._backdrop=null; }
     pop.style.display = 'none';
+    document.body.classList.remove('modal-open');
   }
   function saveCustomTaskFromPopover(){
     const clientId = $('#ctClient').value || '';


### PR DESCRIPTION
## Summary
- Add pop animation to the custom task popover and elevate its overlay
- Lock body scrolling while the custom task popover is open for consistent modal behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa1e3c076c83269cd62216fac0839d