### PR TITLE
feat: add searchable client selector

### DIFF
--- a/app.css
+++ b/app.css
@@ -501,11 +501,11 @@ body.light .ovr-list li{ background:#fff }
 }
 /* Client wider than Type */
 #customTaskPop .row { grid-template-columns: 2fr 1fr; }
-#ctClient { min-width: 320px; }
-#ctClient option { background: var(--panel); color: var(--ink); }
-#ctClient option:hover, #ctClient option:checked { background: #2f3547; color: var(--ink); }
-body.light #ctClient option { background: #fff; color: var(--ink); }
-body.light #ctClient option:hover, body.light #ctClient option:checked { background: #e9ecff; color: #1e2758; }
+#ctClient { width: 100%; }
+#ctClientList option { background: var(--panel); color: var(--ink); }
+#ctClientList option:hover, #ctClientList option:checked { background: #2f3547; color: var(--ink); }
+body.light #ctClientList option { background: #fff; color: var(--ink); }
+body.light #ctClientList option:hover, body.light #ctClientList option:checked { background: #e9ecff; color: #1e2758; }
 
 /* =================== TOAST =================== */
 #toaster{position:fixed;top:14px;right:14px;display:flex;flex-direction:column;gap:12px;z-index:11000;pointer-events:none}

--- a/app.js
+++ b/app.js
@@ -2435,17 +2435,25 @@ if (clientForm) {
   /* ===== Add Custom Task modal ===== */
   function titleDefaultFor(type){ return ({call:'Call', callvm:'Call + Voicemail', sms:'SMS', email:'Email'}[type] || ''); }
   function buildClientOptionsForPopover(){
-    const sel = $('#ctClient'); if(!sel) return;
-    const keep = sel.value;
-    sel.innerHTML = '';
+    const list = $('#ctClientList');
+    const input = $('#ctClient');
+    if(!list || !input) return;
+    const keep = input.dataset.clientId || '';
+    list.innerHTML = '';
     // ✨ Default = None / no client
-    sel.insertAdjacentHTML('beforeend', `<option value="" selected>None — no client</option>`);
+    list.insertAdjacentHTML('beforeend', `<option data-id="" value="None — no client"></option>`);
     const opts = [...state.clients].sort((a,b)=>(b.startDate || '').localeCompare(a.startDate || ''));
     opts.forEach(c=>{
       const label = c.email ? `${c.name} — ${c.email}` : (c.phone ? `${c.name} — ${c.phone}` : c.name);
-      sel.insertAdjacentHTML('beforeend', `<option value="${c.id}">${escapeHtml(label)}</option>`);
+      list.insertAdjacentHTML('beforeend', `<option data-id="${c.id}" value="${escapeHtml(label)}"></option>`);
     });
-    if (keep) sel.value = keep;
+    if (keep){
+      const match = [...list.options].find(o=>o.dataset.id===keep);
+      if (match) input.value = match.value;
+    } else {
+      input.value = '';
+    }
+    input.dataset.clientId = keep;
   }
   function openCustomTaskPopover(){
     buildClientOptionsForPopover();
@@ -2480,6 +2488,7 @@ if (clientForm) {
       const el = $('#'+id); if(!el) return;
       if (id==='ctType') el.value='call'; else el.value='';
     });
+    $('#ctClient').dataset.clientId = '';
     $('#ctImportant').checked = false;
     $('#ctNotify').checked = false; $('#ctNotify').disabled = true;
   }
@@ -2493,7 +2502,7 @@ if (clientForm) {
     document.body.classList.remove('modal-open');
   }
   function saveCustomTaskFromPopover(){
-    const clientId = $('#ctClient').value || '';
+    const clientId = $('#ctClient').dataset.clientId || '';
     const c = clientId ? clientById(clientId) : null;
 
     const type  = $('#ctType').value || 'custom';
@@ -2530,6 +2539,12 @@ if (clientForm) {
     const cur = ($('#ctTitle').value||'').trim();
     const titleDefaults = ['Call','Call + Voicemail','SMS','Email'];
     if (!cur || titleDefaults.includes(cur)) $('#ctTitle').value = titleDefaultFor($('#ctType').value);
+  });
+  $('#ctClient')?.addEventListener('input', ()=>{
+    const list = $('#ctClientList');
+    const val = $('#ctClient').value;
+    const match = list ? [...list.options].find(o=>o.value===val) : null;
+    $('#ctClient').dataset.clientId = match ? (match.dataset.id || '') : '';
   });
   $('#ctTime')?.addEventListener('input', ()=>{
     const has = !!$('#ctTime').value;

--- a/index.html
+++ b/index.html
@@ -247,7 +247,8 @@
               <div class="row">
                 <div>
                   <label>Client</label>
-                  <select id="ctClient"></select>
+                  <input id="ctClient" list="ctClientList" placeholder="Search client…" />
+                  <datalist id="ctClientList"></datalist>
                 </div>
                 <div>
                   <label>Type</label>


### PR DESCRIPTION
## Summary
- replace task client dropdown with searchable input and datalist
- adjust styling so the client field fits beside the type dropdown
- wire up live filtering and selection for clients when creating tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa219114b083268671124568509b49