### PR TITLE
Streamline local time display in task agenda

### DIFF
--- a/app.css
+++ b/app.css
@@ -823,8 +823,12 @@ body.drawer-overlap #app {
 @media (max-width: 900px){
   body.drawer-overlap #app {
     width: 100%;
-    margin-left: 0;
-    margin-right: 0;
+  margin-left: 0;
+  margin-right: 0;
   }
 }
 /* Default state: centered via .wrap margin */
+
+/* Local time colouring */
+.local-time.lt-red{ color: var(--danger); }
+.local-time.lt-green{ color: var(--accent-2); }


### PR DESCRIPTION
## Summary
- Remove local time chip from client list and show timezone in expanded notes
- Add local time next to names in agenda tasks without seconds
- Color local times red before 9AM/after 9PM and green during the day

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa22ac90b883269063a3f631944cf1