### PR TITLE
Display task local time next to client name

### DIFF
--- a/app.css
+++ b/app.css
@@ -296,17 +296,15 @@ body.light .badge, body.light .copy-btn{ background:#fff; color:var(--ink) }
 .pill { font-weight: 400; }
 
 /* Make only the Name pill bolder */
-.agenda-item .pill:first-child,
-.pill.client, .pill--client, .client-pill {
+  .pill.client, .pill--client, .client-pill {
   font-weight: 600;
 }
 
 
 /* Light theme: keep it just a touch stronger (no change in look) */
-body.light .agenda-item .pill:first-child,
-body.light .pill.client,
-body.light .pill--client,
-body.light .client-pill{
+  body.light .pill.client,
+  body.light .pill--client,
+  body.light .client-pill{
   background: #e9edff;
   border-color: #cfd6f8;
   color: #0f1f56;
@@ -760,7 +758,6 @@ body.light #toolRail .tool{
 .pill.client, .pill--client, .client-pill { font-weight:600; }
 
 /* Dark */
-body:not(.light) .agenda-item .pill:first-child,
 body:not(.light) .pill.client,
 body:not(.light) .pill--client,
 body:not(.light) .client-pill{
@@ -770,7 +767,6 @@ body:not(.light) .client-pill{
 }
 
 /* Light */
-body.light .agenda-item .pill:first-child,
 body.light .pill.client,
 body.light .pill--client,
 body.light .client-pill{

--- a/app.js
+++ b/app.js
@@ -1601,15 +1601,14 @@ function renderTask(t, opts = {}){
 
   div.innerHTML = `
     <input type="checkbox" ${t.status==='done'?'checked':''} data-taskid="${t.id}"/>
-    <div>
-      <div><strong>${icon} ${escapeHtml(t.title)}</strong>
-${showClientPill && client ? `<span class="pill client-pill">${escapeHtml(client)}</span>` : ''} ${localTimeHtml}
-        ${contactHtml}
-        ${chipsHtml}
+      <div>
+        <div><strong>${icon} ${escapeHtml(t.title)}</strong> ${contactHtml}
+          ${showClientPill && client ? `<span class="pill client-pill">${escapeHtml(client)}</span>` : ''} ${localTimeHtml}
+          ${chipsHtml}
+        </div>
+        <div class="tiny">${escapeHtml(t.label||'')}${src}</div>
+        ${notesHtml}
       </div>
-      <div class="tiny">${escapeHtml(t.label||'')}${src}</div>
-      ${notesHtml}
-    </div>
     <div class="tiny mono">
       ${t.date}${timeBadged}
       <button class="btn-icon" data-bell="${t.id}" title="Notify at time">🔔</button>


### PR DESCRIPTION
## Summary
- Place contact details before the client name so the time pill sits beside the client's name
- Style client name pill directly rather than relying on the first-pill selector

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa25ea2c9483268296471a1f070a74