### PR TITLE
Show client local time once per client in agenda

### DIFF
--- a/app.css
+++ b/app.css
@@ -296,17 +296,15 @@ body.light .badge, body.light .copy-btn{ background:#fff; color:var(--ink) }
 .pill { font-weight: 400; }
 
 /* Make only the Name pill bolder */
-.agenda-item .pill:first-child,
-.pill.client, .pill--client, .client-pill {
+  .pill.client, .pill--client, .client-pill {
   font-weight: 600;
 }
 
 
 /* Light theme: keep it just a touch stronger (no change in look) */
-body.light .agenda-item .pill:first-child,
-body.light .pill.client,
-body.light .pill--client,
-body.light .client-pill{
+  body.light .pill.client,
+  body.light .pill--client,
+  body.light .client-pill{
   background: #e9edff;
   border-color: #cfd6f8;
   color: #0f1f56;
@@ -760,7 +758,6 @@ body.light #toolRail .tool{
 .pill.client, .pill--client, .client-pill { font-weight:600; }
 
 /* Dark */
-body:not(.light) .agenda-item .pill:first-child,
 body:not(.light) .pill.client,
 body:not(.light) .pill--client,
 body:not(.light) .client-pill{
@@ -770,7 +767,6 @@ body:not(.light) .client-pill{
 }
 
 /* Light */
-body.light .agenda-item .pill:first-child,
 body.light .pill.client,
 body.light .pill--client,
 body.light .client-pill{

--- a/app.js
+++ b/app.js
@@ -1589,7 +1589,7 @@ function renderTask(t, opts = {}){
   }
 
   let localTimeHtml = '';
-  if (c.route){
+  if (c.route && showClientPill){
     const tz = tzFromRoute(c.route);
     localTimeHtml = `<span class="pill"><span class="mono local-time" data-tz="${tz}">${formatTimeInTz(tz)}</span></span>`;
   }
@@ -1601,15 +1601,14 @@ function renderTask(t, opts = {}){
 
   div.innerHTML = `
     <input type="checkbox" ${t.status==='done'?'checked':''} data-taskid="${t.id}"/>
-    <div>
-      <div><strong>${icon} ${escapeHtml(t.title)}</strong>
-${showClientPill && client ? `<span class="pill client-pill">${escapeHtml(client)}</span>` : ''} ${localTimeHtml}
-        ${contactHtml}
-        ${chipsHtml}
+      <div>
+        <div><strong>${icon} ${escapeHtml(t.title)}</strong> ${contactHtml}
+          ${showClientPill && client ? `<span class="pill client-pill">${escapeHtml(client)}</span>` : ''} ${localTimeHtml}
+          ${chipsHtml}
+        </div>
+        <div class="tiny">${escapeHtml(t.label||'')}${src}</div>
+        ${notesHtml}
       </div>
-      <div class="tiny">${escapeHtml(t.label||'')}${src}</div>
-      ${notesHtml}
-    </div>
     <div class="tiny mono">
       ${t.date}${timeBadged}
       <button class="btn-icon" data-bell="${t.id}" title="Notify at time">🔔</button>
@@ -1661,11 +1660,17 @@ function renderGroupedByClient(container, items){
     if (name !== current){
       current = name;
 
-      // Group header with client name + one set of details chips
+      // Group header with client name, local time, and one set of details chips
       const gh = document.createElement('div');
       gh.className = 'group-hd';
+      const c = t.clientId ? clientById(t.clientId) || {} : {};
+      let localTimeHtml = '';
+      if (c.route){
+        const tz = tzFromRoute(c.route);
+        localTimeHtml = `<span class="pill"><span class="mono local-time" data-tz="${tz}">${formatTimeInTz(tz)}</span></span>`;
+      }
       const chipsOnce = detailsChipsFor(t); // uses the task's client
-      gh.innerHTML = `<span class="label">${escapeHtml(name)}</span>${chipsOnce ? `<div class="tiny">${chipsOnce}</div>` : ''}`;
+      gh.innerHTML = `<span class="label">${escapeHtml(name)}</span> ${localTimeHtml}${chipsOnce ? `<div class="tiny">${chipsOnce}</div>` : ''}`;
       container.appendChild(gh);
     }
 


### PR DESCRIPTION
## Summary
- Render client local time in grouped agenda headers so it's shown once per client
- Skip local time pills on individual tasks when grouped by client

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa25ea2c9483268296471a1f070a74