### PR TITLE
Add timezone editing and improved client search

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,6 +97,15 @@
 
           <div class="row">
             <div>
+              <label>Home city</label>
+              <input id="home" list="homeList" placeholder="LAX" />
+              <datalist id="homeList"></datalist>
+            </div>
+            <div></div>
+          </div>
+
+          <div class="row">
+            <div>
               <label>Lead ID</label>
               <input id="leadId" inputmode="numeric" pattern="\d*" placeholder="55471" />
             </div>
@@ -247,7 +256,8 @@
               <div class="row">
                 <div>
                   <label>Client</label>
-                  <select id="ctClient"></select>
+                  <input id="ctClient" list="ctClientList" placeholder="Search client…" />
+                  <datalist id="ctClientList"></datalist>
                 </div>
                 <div>
                   <label>Type</label>


### PR DESCRIPTION
## Summary
- Make local time separator blink every few seconds to show live updates
- Replace custom task client dropdown with searchable datalist
- Allow setting a client's home city to override timezone in displays

## Testing
- `node --check app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2c60c9c48326af41ef605fe80813