### PR TITLE
Improve navigation and drawer behavior

### DIFF
--- a/app.css
+++ b/app.css
@@ -277,6 +277,7 @@ body.modal-open{ overflow:hidden; }
   font-weight:400;
 }
 .pill a{ color:inherit; font-weight:inherit; }  /* no blue links inside pills */
+.client-pill, .cust-link{ cursor:pointer; }
 
 /* Light pills */
 body.light .pill{ background:var(--pill-li-bg); border:1px solid var(--pill-li-br); color:var(--pill-li-fg); font-weight:400; }
@@ -444,7 +445,7 @@ body.light #calSettings{ background:#fff }
 .ovr{
   margin-top:14px;
   display:grid;
-  grid-template-columns: minmax(140px,1fr) max-content max-content;
+  grid-template-columns: minmax(140px,1fr) auto auto;
   align-items:end;
   gap:10px;
 }
@@ -634,7 +635,7 @@ body.light input[type="checkbox"]:checked{
   background: var(--panel);
   border-left: 1px solid var(--line);
   box-shadow: -10px 0 24px rgba(0,0,0,.18);
-  transform: translateX(100%);
+  transform: translateX(calc(100% + var(--rail-w)));
   transition: transform .28s cubic-bezier(.2,.8,.2,1);
   display: flex; flex-direction: column;
   pointer-events: auto;                                  /* panel clickable */

--- a/app.js
+++ b/app.js
@@ -273,7 +273,7 @@ function tzAbbr(tz){
 
 function updateLocalTimes(){
   const now = new Date();
-  const blink = Math.floor(now.getTime() / 3000) % 2 === 0;
+  const blink = Math.floor(now.getTime() / 1000) % 2 === 0;
   $$('.local-time').forEach(el=>{
     const tz = el.getAttribute('data-tz');
     if(!tz) return;
@@ -1364,7 +1364,7 @@ const contactHtml = `
 
   tr.innerHTML = `
   <td data-label="Name">
-    <strong>${escapeHtml(c.name)}</strong>
+    <span class="pill client-pill cust-link" data-name="${escapeHtml(c.name)}">${escapeHtml(c.name)}</span>
     <div class="tiny mono note-preview" data-act="note" data-id="${c.id}" title="Click to expand notes">
       ${c.notes ? escapeHtml(truncate(c.notes)) : ''}
     </div>
@@ -1420,6 +1420,18 @@ const nameText =
   }
 
 $('#clientsTbl')?.addEventListener('click', e=>{
+  const link = e.target.closest('.cust-link');
+  if (link){
+    const name = link.getAttribute('data-name') || link.textContent.trim();
+    const af = document.getElementById('agendaFilter');
+    if (af){
+      af.value = name;
+      af.dispatchEvent(new Event('input'));
+      af.scrollIntoView({ behavior:'smooth', block:'center' });
+      af.focus();
+    }
+    return;
+  }
   // Toggle notes when clicking the inline preview
   const preview = e.target.closest('.note-preview');
   if (preview){
@@ -2601,6 +2613,18 @@ if (clientForm) {
   });
 
   $('#agenda')?.addEventListener('click', (e)=>{
+  const cp = e.target.closest('.client-pill');
+  if (cp){
+    const name = cp.textContent.trim();
+    const search = document.getElementById('search');
+    if (search){
+      search.value = name;
+      search.dispatchEvent(new Event('input'));
+      search.scrollIntoView({ behavior:'smooth', block:'center' });
+      search.focus();
+    }
+    return;
+  }
   const del = e.target.closest('[data-del]');
   if (del){
     const id = del.getAttribute('data-del');

--- a/index.html
+++ b/index.html
@@ -368,7 +368,7 @@
                 </select>
               </div>
               <div style="display:flex;align-items:flex-end">
-                <button id="addOverride">Add override</button>
+                <button id="addOverride">Add</button>
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Speed up clock colon blink
- Hide names and calendar drawers completely when closed
- Cross-link customer name pills between Agenda and Customers
- Rename and stabilize Add button in calendar settings

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa2fb804fc83269d67284e7124d29b