### PR TITLE
Fix agenda name pill and add hover effect

### DIFF
--- a/app.css
+++ b/app.css
@@ -279,6 +279,19 @@ body.modal-open{ overflow:hidden; }
 .pill a{ color:inherit; font-weight:inherit; }  /* no blue links inside pills */
 .client-pill, .cust-link{ cursor:pointer; }
 
+/* Hover effect for clickable pills */
+.client-pill:hover,
+.cust-link:hover,
+#namesList .name-pill:hover{
+  filter:brightness(1.08);
+}
+
+body.light .client-pill:hover,
+body.light .cust-link:hover,
+body.light #namesList .name-pill:hover{
+  filter:brightness(.95);
+}
+
 /* Light pills */
 body.light .pill{ background:var(--pill-li-bg); border:1px solid var(--pill-li-br); color:var(--pill-li-fg); font-weight:400; }
 

--- a/app.js
+++ b/app.js
@@ -1706,7 +1706,7 @@ function renderGroupedByClient(container, items){
         localTimeHtml = `<span class="pill"><span class="mono local-time" data-tz="${tz}">${formatTimeInTz(tz)}</span></span>`;
       }
       const chipsOnce = detailsChipsFor(t); // uses the task's client
-      gh.innerHTML = `<span class="label">${escapeHtml(name)}</span> ${localTimeHtml}${chipsOnce ? `<div class="tiny">${chipsOnce}</div>` : ''}`;
+      gh.innerHTML = `<span class="pill client-pill">${escapeHtml(name)}</span> ${localTimeHtml}${chipsOnce ? `<div class="tiny">${chipsOnce}</div>` : ''}`;
       container.appendChild(gh);
     }
 


### PR DESCRIPTION
## Summary
- Make grouped-by-client agenda show client pill so names are clickable
- Add subtle hover effect for clickable pills

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa32834abc83268a8416a94ec95533