### PR TITLE
Add clear search control and today's task counter

### DIFF
--- a/app.js
+++ b/app.js
@@ -1306,7 +1306,9 @@ function refresh(){
   $('#kTotal').textContent = state.clients.length;
   $('#kUn').textContent    = state.clients.filter(c=>c.status==='unreached').length;
   $('#kRe').textContent    = state.clients.filter(c=>c.status==='reached').length;
-  $('#kTasks').textContent = state.tasks.filter(t=>t.status==='open').length;
+    const todayStr = fmt(today());
+    const leftToday = state.tasks.filter(t=>t.status!=='done' && t.date===todayStr).length;
+    $('#kTasks').textContent = leftToday + ' left';
 
   const body = $('#clientsTbl tbody'); 
   body.innerHTML = '';
@@ -2725,15 +2727,30 @@ afterLayout();
 centerMainCards();
 // 🔎 Customers search + status filter
 const searchEl = document.getElementById('search');
+const clearSearchBtn = document.getElementById('clearSearch');
 if (searchEl){
   let raf = 0;
   const apply = () => { cancelAnimationFrame(raf); raf = requestAnimationFrame(refresh); };
+  const toggleClear = () => {
+    if (!clearSearchBtn) return;
+    clearSearchBtn.style.display = searchEl.value ? 'inline-flex' : 'none';
+  };
 
-  searchEl.addEventListener('input', apply);               // live as you type
+  searchEl.addEventListener('input', () => { toggleClear(); apply(); });               // live as you type
   // ❌ remove the 'change' listener that was here
   searchEl.addEventListener('keydown', (e)=>{
-    if (e.key === 'Escape'){ searchEl.value=''; apply(); } // Esc to clear
+    if (e.key === 'Escape'){ searchEl.value=''; toggleClear(); apply(); } // Esc to clear
   });
+
+  if (clearSearchBtn){
+    clearSearchBtn.addEventListener('click', () => {
+      searchEl.value='';
+      toggleClear();
+      apply();
+      searchEl.focus();
+    });
+    toggleClear();
+  }
 }
 
 document.getElementById('statusFilter')

--- a/index.html
+++ b/index.html
@@ -146,6 +146,7 @@
         <button id="openAdd" class="btn-icon add-btn" title="Add customer" aria-label="Add customer">＋</button>
         <div class="space"></div>
         <input id="search" placeholder="Search name, email, phone…" />
+        <button id="clearSearch" class="btn-icon" title="Clear search" aria-label="Clear search" style="display:none">✖</button>
         <select id="statusFilter" title="Filter by status" style="max-width:160px">
           <option value="">All</option>
           <option value="unreached">Unreached</option>
@@ -157,8 +158,8 @@
           <div class="box"><div class="tiny">Total</div><div id="kTotal" class="num">0</div></div>
           <div class="box"><div class="tiny">Unreached</div><div id="kUn" class="num">0</div></div>
           <div class="box"><div class="tiny">Reached</div><div id="kRe" class="num">0</div></div>
-          <div class="box"><div class="tiny">Open tasks</div><div id="kTasks" class="num">0</div></div>
-        </div>
+            <div class="box"><div class="tiny">Today's tasks</div><div id="kTasks" class="num">0 left</div></div>
+          </div>
 
         <div class="mt16 customers-scroll" style="margin-top:12px; max-height:50vh; overflow-y:auto; overflow-x:hidden;">
           <table class="tbl" id="clientsTbl">


### PR DESCRIPTION
## Summary
- add button to clear customer search
- show today's tasks left instead of open tasks

## Testing
- `node --check app.js`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68aa35cf2f388326b392c0717976f042