### PR TITLE
Improve name copy UX and sticky More panel actions

### DIFF
--- a/app.css
+++ b/app.css
@@ -66,6 +66,7 @@ body.light{
 /* =================== BASE =================== */
 *{box-sizing:border-box}
 html,body{height:100%; max-width:100%; overflow-x:hidden}
+html{scroll-behavior:smooth;}
 :root{ color-scheme: dark light; }
 body{ color-scheme: dark; }
 body.light{ color-scheme: light; }
@@ -246,11 +247,17 @@ body.modal-open{ overflow:hidden; }
   width:36px; height:36px; border-radius:999px;
   background:linear-gradient(180deg,var(--accent),#5d6ef2);
   color:#fff; border:1px solid #5865f2;
-  box-shadow:var(--sh-1);
+  box-shadow:var(--sh-1), 0 0 8px var(--accent);
   font-weight:900; line-height:1; padding:0;
+  animation:add-glow 2s ease-in-out infinite alternate;
 }
 .add-btn:hover{ filter:brightness(1.06); transform:translateY(-1px); }
 .add-btn:active{ transform:translateY(0); }
+
+@keyframes add-glow{
+  from{ box-shadow:var(--sh-1), 0 0 8px var(--accent); }
+  to{ box-shadow:var(--sh-1), 0 0 16px var(--accent); }
+}
 
 /* Sticky footer for the Add/Edit form */
 #addCard .bd{ padding-bottom:74px; }
@@ -755,6 +762,31 @@ body.light #toolRail .tool{
 .modal .card{
   width:min(920px, 100%); max-height:88vh; overflow:auto; animation:pop .16s ease-out;
 }
+
+#moreModal .card{
+  display:flex;
+  flex-direction:column;
+  overflow:hidden;
+}
+#moreModal .card .bd{
+  flex:1;
+  display:flex;
+  flex-direction:column;
+}
+#moreModal #moreContent{
+  flex:1;
+  overflow:auto;
+  padding-bottom:60px;
+}
+#moreModal .more-actions{
+  position:sticky;
+  bottom:0;
+  background:var(--panel);
+  margin-top:auto;
+  padding-top:10px;
+  padding-bottom:10px;
+  border-top:1px solid var(--line);
+}
 @keyframes pop{ from{ opacity:0; transform:translateY(8px) scale(.985) } to{ opacity:1; transform:none } }
 #addCard{ display:none; }
 
@@ -799,6 +831,12 @@ body.light .client-pill{
 #namesList .name-pill{
   cursor: pointer;                /* make it feel clickable */
   min-height: 32px;
+  border:1px solid var(--accent);
+  transition: box-shadow .2s;
+}
+
+#namesList .name-pill:hover{
+  box-shadow:0 0 4px var(--accent);
 }
 
 /* clicked/used state — dim + desaturate, but keep it active */
@@ -806,6 +844,7 @@ body.light .client-pill{
   color: var(--muted);
   opacity: .70;
   filter: grayscale(60%);
+  border-color: var(--line);
 }
 
 /* keep a clear keyboard focus outline for accessibility */

--- a/app.js
+++ b/app.js
@@ -416,9 +416,9 @@ function computeSmsText(t, client){
   function truncate(s, n=90){ if(!s) return ''; return s.length>n ? s.slice(0,n-1)+'…' : s; }
 
   // Copy helper + tiny copy buttons
-  function copyTextToClipboard(text, what='value'){
+  function copyTextToClipboard(text, what='value', silent=false){
     if(!text) return;
-    const done = () => toast(`Copied ${what}`, 'ok', 900);
+    const done = () => { if(!silent) toast(`Copied ${what}`, 'ok', 900); };
     try{
       if (navigator.clipboard && navigator.clipboard.writeText){
         navigator.clipboard.writeText(text).then(done).catch(()=>{
@@ -662,10 +662,17 @@ btn.addEventListener('click', () => {
     btn.textContent = n;
     btn.title = 'Click to copy';
     btn.addEventListener('click', () => {
-      copyTextToClipboard(n, 'name'); // you already have this helper
-      btn.classList.add('used');      // gray it out (but keep it usable)
+      copyTextToClipboard(n, 'name', true);
+      const original = n;
+      btn.classList.remove('used');
+      btn.textContent = '✔ Copied name';
+      setTimeout(() => {
+        btn.textContent = original;
+        btn.classList.add('used');
+      }, 500);
     });
-listEl.appendChild(btn);  });
+    listEl.appendChild(btn);
+  });
 }
 function renderNames(){
  const uniqFirst = [...new Set(FIRST.map(s => s.trim()))];
@@ -1430,7 +1437,7 @@ $('#clientsTbl')?.addEventListener('click', e=>{
       af.value = name;
       af.dispatchEvent(new Event('input'));
       af.scrollIntoView({ behavior:'smooth', block:'center' });
-      af.focus();
+      setTimeout(() => af.focus(), 300);
     }
     return;
   }
@@ -1905,7 +1912,7 @@ function initMorePanel(){
           </div>
         </div>
 
-        <div class="right" style="margin-top:10px">
+        <div class="right more-actions">
           <button type="button" class="ghost" id="moreReset">Reset to defaults</button>
           <button type="button" id="moreCancel" class="ghost">Cancel</button>
           <button type="button" id="moreSave" class="primary">Save</button>
@@ -2623,7 +2630,7 @@ if (clientForm) {
       search.value = name;
       search.dispatchEvent(new Event('input'));
       search.scrollIntoView({ behavior:'smooth', block:'center' });
-      search.focus();
+      setTimeout(() => search.focus(), 300);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- Make More panel action buttons stick to the bottom
- Add animated glow to plus button and highlight name pills as clickable
- Enhance name copy behavior with inline feedback and smoother scrolling to filters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa423db3ac83269ccad47608bfee7f