### PR TITLE
Fix modal overlays and link styling

### DIFF
--- a/app.css
+++ b/app.css
@@ -286,8 +286,7 @@ body.modal-open{ overflow:hidden; }
 .pill a{ color:inherit; font-weight:inherit; }  /* no blue links inside pills */
 .client-pill, .cust-link{
   cursor:pointer;
-  text-decoration:underline;
-  text-underline-offset:2px;
+  text-decoration:none;
 }
 
 /* Hover effect for clickable pills */
@@ -778,7 +777,7 @@ body.light #toolRail .tool{
   flex-direction:column;
 
   overflow:auto;
-  padding-bottom:60px;
+  padding-bottom:110px;
 }
 #moreModal .more-actions{
   position:sticky;
@@ -788,6 +787,7 @@ body.light #toolRail .tool{
   padding-top:10px;
   padding-bottom:10px;
   border-top:1px solid var(--line);
+  z-index:1;
 }
 @keyframes pop{ from{ opacity:0; transform:translateY(8px) scale(.985) } to{ opacity:1; transform:none } }
 #addCard{ display:none; }
@@ -828,6 +828,12 @@ body.light .client-pill{
 /* Keep links inside pills from turning blue */
 .pill a { color: inherit !important; }
 
+/* underline CRM lead IDs */
+.lead-id{
+  text-decoration: underline;
+  text-underline-offset:2px;
+}
+
 
 /* ========== Random Names: gray-out after click (still clickable) ========== */
 #namesList .name-pill{
@@ -859,6 +865,14 @@ body.light .client-pill{
 body.light #namesList .name-pill.used{
   opacity: .65;
   filter: grayscale(40%);
+}
+
+/* manual follow-up row layout */
+.manual-row .slab{
+  display:flex;
+  align-items:center;
+  gap:6px;
+  flex-wrap:wrap;
 }
 /* When a drawer overlaps, shrink the main app width and reserve space to the right */
 body.drawer-overlap #app {

--- a/app.js
+++ b/app.js
@@ -234,8 +234,7 @@ function inferDestination(route){
 // IATA → IANA timezone map is loaded separately (see iata-tz.js)
 function tzFromRoute(route){
   const first = String(route||'').toUpperCase().split(/[-–—>\s]+/).filter(Boolean)[0];
-  return window.IATA_TZ?.[first] || Intl.DateTimeFormat().resolvedOptions().timeZone;
-
+  return window.IATA_TZ?.[first] || '';
 }
 
 function clientTz(c){
@@ -1187,7 +1186,7 @@ function crmLeadUrl(id){
 function leadChipHtml(id){
   const url = crmLeadUrl(id);
   return url
-    ? `<span class="pill">Lead:&nbsp;<a class="mono" href="${url}" target="_blank" rel="noopener">${escapeHtml(String(id))}</a></span>`
+    ? `<span class="pill">Lead:&nbsp;<a class="mono lead-id" href="${url}" target="_blank" rel="noopener">${escapeHtml(String(id))}</a></span>`
     : '';
 }
 
@@ -1536,7 +1535,7 @@ $('#clientsTbl')?.addEventListener('click', e=>{
         <input type="text" id="manualNotes_${id}" placeholder="Optional notes" style="min-width:220px" />
         <span>Creates: 2 Calls, 1 SMS, 1 Email.</span>
         <span class="space"></span>
-        <button class="primary" data-act="manual-apply" data-id="${id}">Schedule</button>
+        <button class="primary" data-act="manual-apply" data-id="${id}">Add</button>
         <button data-act="manual-cancel" data-id="${id}">Cancel</button>
       </div>`;
     row.appendChild(td); tr.after(row);


### PR DESCRIPTION
## Summary
- Prevent modal content from showing behind action buttons
- Clarify manual follow‑up scheduling and show add button
- Improve link styling for customer names and lead IDs
- Hide local-time display when airport code is unknown

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4a14f8388326a95f47404720cee6