### PR TITLE
Improve modal layout and destination handling

### DIFF
--- a/app.css
+++ b/app.css
@@ -296,6 +296,13 @@ body.modal-open{ overflow:hidden; }
   filter:brightness(1.08);
 }
 
+body:not(.light) .client-pill:hover,
+body:not(.light) .cust-link:hover,
+body:not(.light) #namesList .name-pill:hover{
+  filter:brightness(1.15);
+  box-shadow:0 0 4px var(--accent);
+}
+
 body.light .client-pill:hover,
 body.light .cust-link:hover,
 body.light #namesList .name-pill:hover{
@@ -404,7 +411,17 @@ body.light .group-hd .label{ background:#fff; }
 .progress > span{display:block; height:100%; background:linear-gradient(90deg,var(--accent),var(--accent-2)); width:0}
 
 /* Inline notify editor */
-.notify-row{ display:flex; align-items:center; gap:10px; margin:6px 0 0 38px; padding:10px; border:1px dashed var(--line); border-radius:12px; background:var(--surface); }
+.notify-row{
+  display:flex;
+  align-items:center;
+  gap:10px;
+  margin:6px 0 0 0;
+  padding:10px;
+  border:1px dashed var(--line);
+  border-radius:12px;
+  background:var(--surface);
+  grid-column:2 / span 2;
+}
 .notify-row input[type="time"]{ height:34px; }
 .notify-row button{ height:34px; }
 /* Agenda group header name (when sorting By client) */
@@ -777,17 +794,12 @@ body.light #toolRail .tool{
   flex-direction:column;
 
   overflow:auto;
-  padding-bottom:110px;
+  padding:0 0 10px 0;
 }
 #moreModal .more-actions{
-  position:sticky;
-  bottom:0;
   background:var(--panel);
-  margin-top:auto;
-  padding-top:10px;
-  padding-bottom:10px;
   border-top:1px solid var(--line);
-  z-index:1;
+  padding:10px 0;
 }
 @keyframes pop{ from{ opacity:0; transform:translateY(8px) scale(.985) } to{ opacity:1; transform:none } }
 #addCard{ display:none; }

--- a/app.js
+++ b/app.js
@@ -225,10 +225,22 @@ function removeInert(el){
 }
 
 // Pull last IATA in route (e.g., JFK-NAP -> NAP) → naive city map
-const IATA_CITY = { NAP: 'Naples', LHR: 'London', CDG: 'Paris', FCO: 'Rome' /* …extend… */ };
+const IATA_CITY = {
+  NAP: 'Naples',
+  LHR: 'London',
+  CDG: 'Paris',
+  FCO: 'Rome',
+  DFW: 'Dallas',
+  BRU: 'Brussels',
+  /* …extend… */
+};
 function inferDestination(route){
-  const last = String(route||'').toUpperCase().split(/[-–—>\s]+/).filter(Boolean).pop();
-  return IATA_CITY[last] || last || 'your destination';
+  const legs = String(route||'').toUpperCase().split(/[-–—>\s]+/).filter(Boolean);
+  if (!legs.length) return 'your destination';
+  let code;
+  if (legs.length >= 3 && legs[0] === legs[legs.length - 1]) code = legs[legs.length - 2];
+  else code = legs[legs.length - 1];
+  return IATA_CITY[code] || code || 'your destination';
 }
 
 // IATA → IANA timezone map is loaded separately (see iata-tz.js)
@@ -1910,12 +1922,12 @@ function initMorePanel(){
             </div>
           </div>
         </div>
+      </div>
 
-        <div class="right more-actions">
-          <button type="button" class="ghost" id="moreReset">Reset to defaults</button>
-          <button type="button" id="moreCancel" class="ghost">Cancel</button>
-          <button type="button" id="moreSave" class="primary">Save</button>
-        </div>
+      <div class="right more-actions">
+        <button type="button" class="ghost" id="moreReset">Reset to defaults</button>
+        <button type="button" id="moreCancel" class="ghost">Cancel</button>
+        <button type="button" id="moreSave" class="primary">Save</button>
       </div>
     </section>
   `;


### PR DESCRIPTION
## Summary
- Move “Reset to defaults”, “Cancel”, and “Save” controls to the very bottom of the More Settings modal
- Fix custom notification editor layout so “Notify @” label displays correctly
- Resolve destination detection for round trips and add Dallas mapping; enhance dark mode name pill hover with subtle glow

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68aa4f575d50832688e0589eb6b40998