### PR TITLE
feat: expand customer panel and organize settings

### DIFF
--- a/app.css
+++ b/app.css
@@ -796,6 +796,10 @@ body.light #toolRail .tool{
   overflow:auto;
   padding:0 20px 10px;
 }
+#moreModal .tabs{ margin:10px 0; }
+#moreModal .tabs button{ flex:1; }
+#moreModal .tab-pane{ display:none; }
+#moreModal .tab-pane.active{ display:block; }
 #moreModal .more-actions{
   background:var(--panel);
   border-top:1px solid var(--line);

--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
             <div class="box"><div class="tiny">Today's tasks</div><div id="kTasks" class="num">0 left</div></div>
           </div>
 
-        <div class="mt16 customers-scroll" style="margin-top:12px; max-height:50vh; overflow-y:auto; overflow-x:hidden;">
+        <div class="mt16 customers-scroll" style="margin-top:12px; max-height:70vh; overflow-y:auto; overflow-x:hidden;">
           <table class="tbl" id="clientsTbl">
             <thead>
               <tr>


### PR DESCRIPTION
## Summary
- make customers list taller for easier browsing
- organize More modal with tabs for agent info and SMS templates
- offer option to add an extra Phase 1 day after completing day 3 tasks

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa582ad838832689ce4dc35f5062fd