### PR TITLE
Keep agent modal tabs visible and relocate wipe all control

### DIFF
--- a/app.css
+++ b/app.css
@@ -182,11 +182,11 @@ button.primary{
   background:linear-gradient(180deg,var(--accent),#5d6ef2);
   border-color:color-mix(in oklab, var(--accent) 70%, black 10%); color:#fff;
 }
-/* Danger button (used by “Wipe All”) */
+/* Danger button (used by “Wipe All Data”) */
 
 
 button.ghost{ background:transparent; }
-/* === Wipe All button — mimic Calendar "off day" tile GOOD BTN DANGER=== */
+/* === Wipe All Data button — mimic Calendar "off day" tile GOOD BTN DANGER=== */
 .btn-danger{
   /* same vibe as .cal-cell.offday in dark */
   background:
@@ -796,7 +796,13 @@ body.light #toolRail .tool{
   overflow:auto;
   padding:0 20px 10px;
 }
-#moreModal .tabs{ margin:10px 0; }
+#moreModal .tabs{
+  margin:10px 0;
+  position:sticky;
+  top:0;
+  z-index:1;
+  background:var(--panel);
+}
 #moreModal .tabs button{ flex:1; }
 #moreModal .tab-pane{ display:none; }
 #moreModal .tab-pane.active{ display:block; }

--- a/app.js
+++ b/app.js
@@ -1923,7 +1923,7 @@ function initMorePanel(){
       </div>
       <div class="bd">
         <div class="seg tabs" id="moreTabs">
-          <button data-tab="agent" class="active">Agent</button>
+          <button data-tab="agent" class="primary">Agent</button>
           <button data-tab="unr">Unreached SMS</button>
           <button data-tab="rch">Reached SMS</button>
         </div>
@@ -1960,6 +1960,9 @@ function initMorePanel(){
                 <input type="checkbox" id="moveOffDays2"> Move tasks off non-working days
               </label>
             </div>
+          </div>
+          <div class="slab" style="margin-top:10px">
+            <button type="button" class="btn-danger" id="wipeAll" title="Delete all data">Wipe All Data</button>
           </div>
         </div>
         <div id="tab_unr" class="tab-pane">
@@ -2025,7 +2028,6 @@ function initMorePanel(){
       </div>
 
       <div class="right more-actions">
-        <button type="button" class="btn-danger" id="wipeAll" title="Delete all data">Wipe All</button>
         <button type="button" class="ghost" id="moreReset">Reset to defaults</button>
         <button type="button" id="moreCancel" class="ghost">Cancel</button>
         <button type="button" id="moreSave" class="primary">Save</button>
@@ -2036,12 +2038,14 @@ function initMorePanel(){
   initNotificationsUI();
   const tabBtns = modal.querySelectorAll('#moreTabs button');
   const panes = modal.querySelectorAll('.tab-pane');
+  const scrollArea = modal.querySelector('.bd');
   tabBtns.forEach(btn=>{
     btn.addEventListener('click', ()=>{
-      tabBtns.forEach(b=>b.classList.remove('active'));
+      tabBtns.forEach(b=>b.classList.remove('primary'));
       panes.forEach(p=>p.classList.remove('active'));
-      btn.classList.add('active');
+      btn.classList.add('primary');
       modal.querySelector('#tab_'+btn.dataset.tab).classList.add('active');
+      scrollArea.scrollTop = 0;
     });
   });
 // --- Make SMS template textareas bigger + auto-grow ---
@@ -2636,7 +2640,7 @@ document.getElementById('saveCustomer')?.addEventListener('click', (e) => {
       closeAddModal();
     }catch(e){
       console.error(e);
-      alert('Could not save customer. If this persists, click “Wipe All” to clear local data and try again.');
+      alert('Could not save customer. If this persists, click “Wipe All Data” to clear local data and try again.');
       toast('Save failed', 'err', 2200);
     }
   });


### PR DESCRIPTION
## Summary
- Highlight Agent tab by default and keep tab bar visible when switching tabs
- Rename “Wipe All” to “Wipe All Data” and move it into the Agent tab
- Ensure modal tab buttons reset scroll position for easier navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5b6343088326b30c8b6bcc81ca6b