### PR TITLE
Adjust agenda scrolling to account for header height

### DIFF
--- a/app.js
+++ b/app.js
@@ -2489,10 +2489,10 @@ function notifyTask(t){
           ad.dispatchEvent(new Event('change'));
         }
         const target = document.getElementById('actionsCard');
-        if (target?.scrollIntoView){
-          target.scrollIntoView({ behavior:'smooth', block:'start' });
-        } else if (target){
-          window.scrollTo({ top: target.offsetTop - 70, behavior:'smooth' });
+        if (target){
+          const headerH = parseFloat(getComputedStyle(document.documentElement).getPropertyValue('--header-h')) || 0;
+          const y = target.getBoundingClientRect().top + window.scrollY - headerH;
+          window.scrollTo({ top: y, behavior:'smooth' });
         }
       });
 


### PR DESCRIPTION
## Summary
- Fix calendar day click scrolling so the Agenda panel sits directly below the sticky FollowUp CRM header

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5f3b6e748326a98d09eb0d919a7e