### PR TITLE
Expose time override control and show local clock

### DIFF
--- a/app.css
+++ b/app.css
@@ -918,7 +918,7 @@ body.drawer-overlap #app {
 
 #devTimeCtrl{
   position:fixed;
-  top:4px;
+  top:calc(var(--header-h) + 8px);
   left:4px;
   z-index:1000;
   display:flex;

--- a/app.js
+++ b/app.js
@@ -2913,6 +2913,13 @@ function centerMainCards(){
 function initTimeControl(){
   const input = document.getElementById('timeOverride');
   const reset = document.getElementById('timeOverrideReset');
+  const localTimeEl = document.getElementById('localTime');
+  if(localTimeEl){
+    try{
+      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+      localTimeEl.setAttribute('data-tz', tz);
+    }catch(_){ /* ignore */ }
+  }
   if(!input || !reset) return;
   if(state.settings.timeOverride){
     input.value = state.settings.timeOverride;

--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
 </head>
 <body>
   <div id="devTimeCtrl" class="dev-time-ctrl">
+    <span class="tiny">Local: <span id="localTime" class="mono local-time"></span></span>
     <input type="datetime-local" id="timeOverride" title="Override local time" />
     <button id="timeOverrideReset" class="tiny">Reset</button>
   </div>


### PR DESCRIPTION
## Summary
- Move developer time override control below the header so it is visible
- Display the user's local time and wire it to the existing clock updater

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa5fc39ad483269dda4739c3980e8c