### PR TITLE
feat: improve calendar navigation and header layout

### DIFF
--- a/app.css
+++ b/app.css
@@ -104,6 +104,18 @@ header .wrap{ padding-block:10px; }
 h1{font-size:28px; margin:0 0 4px; font-weight:800; line-height:1.1}
 .sub{color:var(--muted); font-size:13.5px}
 
+.dev-time-ctrl{
+  display:flex;
+  align-items:center;
+  gap:6px;
+}
+.dev-time-ctrl input,
+.dev-time-ctrl button{
+  height:28px;
+  padding:4px 8px;
+}
+.dev-time-ctrl .tiny{white-space:nowrap;}
+
 /* =================== CARDS / CONTROLS =================== */
 .card{background:var(--panel); border:1px solid var(--line); border-radius:20px; box-shadow:var(--sh-1);} 
 .card .hd{

--- a/app.js
+++ b/app.js
@@ -199,6 +199,15 @@ function formatName(last, first){
   return `-${String(last||'').toUpperCase()}/${String(first||'')}`;
 }
 
+function scrollAgendaIntoView(){
+  const target = document.getElementById('actionsCard');
+  if(!target) return;
+  const header = document.querySelector('header');
+  const headerH = header ? header.getBoundingClientRect().height : 0;
+  const y = target.getBoundingClientRect().top + window.scrollY - headerH;
+  window.scrollTo({ top: y, behavior:'smooth' });
+}
+
 // Pick n unique combos; falls back to best effort if arrays are tiny
 function pickUniqueCombos(firsts, lasts, n=9){
   const out = new Set();
@@ -2156,6 +2165,7 @@ function initMorePanel(){
       btn.classList.add('primary');
       modal.querySelector('#tab_'+btn.dataset.tab).classList.add('active');
       scrollArea.scrollTop = 0;
+      modal.scrollTop = 0;
     });
   });
 // --- Make SMS template textareas bigger + auto-grow ---
@@ -2277,6 +2287,7 @@ function loadIntoUI(){
    modal.style.display='flex';
    modal.style.pointerEvents='auto';
    modal.classList.add('open');
+   modal.scrollTop = 0;
    loadIntoUI();
    wireAutoGrow();
    document.body.classList.add('modal-open');
@@ -2577,13 +2588,7 @@ function notifyTask(t){
           ad.value = ymd;
           ad.dispatchEvent(new Event('change'));
         }
-        const target = document.getElementById('actionsCard');
-        if (target){
-          const header = document.querySelector('header');
-          const headerH = header ? header.getBoundingClientRect().height : 0;
-          const y = target.getBoundingClientRect().top + window.scrollY - headerH;
-          window.scrollTo({ top: y, behavior:'smooth' });
-        }
+        scrollAgendaIntoView();
       });
 
       grid.appendChild(cell);

--- a/index.html
+++ b/index.html
@@ -16,11 +16,6 @@
   <script src="./app.js" defer></script>
 </head>
 <body>
-  <div id="devTimeCtrl" class="dev-time-ctrl">
-    <span class="tiny">Local: <span id="localTime" class="mono local-time"></span></span>
-    <input type="datetime-local" id="timeOverride" title="Override local time" />
-    <button id="timeOverrideReset" class="tiny">Reset</button>
-  </div>
   <!-- Sticky right-edge tabs -->
   <aside id="toolRail" aria-label="Tools">
     <button class="tool" data-target="calendarDrawer" aria-pressed="false" title="Calendar">
@@ -33,6 +28,11 @@
 
   <header>
     <div class="wrap" style="display:flex; align-items:center; gap:12px">
+      <div id="devTimeCtrl" class="dev-time-ctrl">
+        <span class="tiny">Local: <span id="localTime" class="mono local-time"></span></span>
+        <input type="datetime-local" id="timeOverride" title="Override local time" />
+        <button id="timeOverrideReset" class="tiny">Reset</button>
+      </div>
       <div>
         <h1>Follow-Up CRM LAB!</h1>
         <div class="sub">Local-only CRM (HTML + CSS + JS) for <b>Unreached</b> and <b>Reached</b> customers, agenda & calendar—no servers or logins.</div>


### PR DESCRIPTION
## Summary
- Move local time override picker into the header
- Scroll agenda into view when selecting a day in the calendar
- Keep SMS template modal anchored when switching tabs

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa6a303a20832683c66f984722dbc0