### PR TITLE
Fix 'More' panel textarea auto-grow

### DIFF
--- a/app.js
+++ b/app.js
@@ -2168,8 +2168,7 @@ function initMorePanel(){
       modal.scrollTop = 0;
     });
   });
-// --- Make SMS template textareas bigger + auto-grow ---
-{
+  // --- Make SMS template textareas bigger + auto-grow ---
   // 1) CSS: full width, larger minimum height, vertical resize only
   if (!document.getElementById('moreModalTextareaStyles')) {
     const st = document.createElement('style');
@@ -2194,7 +2193,10 @@ function initMorePanel(){
     el.style.height = 'auto';
     el.style.height = (el.scrollHeight + 2) + 'px';
   };
+  let autoGrowWired = false;
   const wireAutoGrow = () => {
+    if (autoGrowWired) return;
+    autoGrowWired = true;
     modal.querySelectorAll('textarea[id^="tpl_unr_"], textarea[id^="tpl_rch_"]').forEach(t => {
       // autoGrow(t);                       // fit on open
       t.addEventListener('input', () => autoGrow(t)); // fit while typing
@@ -2202,8 +2204,6 @@ function initMorePanel(){
   };
 
   // Run auto-grow after values are populated
-
-}
 
 function loadIntoUI(){
   const a = state.settings.agent || {};


### PR DESCRIPTION
## Summary
- Ensure `initMorePanel` exposes auto-grow helpers so the 'More' settings modal works without runtime errors
- Guard textarea auto-grow wiring to avoid stacking duplicate listeners

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_68aabc337e4083268a5d129000e9d101