### PR TITLE
Fix More modal overflow for dropdowns on mobile

### DIFF
--- a/app.css
+++ b/app.css
@@ -806,7 +806,8 @@ body.light #toolRail .tool{
 #moreModal .card{
   display:flex;
   flex-direction:column;
-  overflow:hidden;
+  /* Allow dropdowns (e.g., datalist suggestions) to escape the card on mobile */
+  overflow:visible;
 }
 #moreModal .card .bd{
   flex:1;


### PR DESCRIPTION
## Summary
- allow dropdowns like datalist suggestions to display in the More modal by using `overflow: visible`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aabee8dce08326b2acc43e1b3ad61b