### PR TITLE
Ensure toast notifications overlay modals

### DIFF
--- a/app.css
+++ b/app.css
@@ -563,7 +563,7 @@ body.light .ovr-list li{ background:#fff }
 #ctClient { width: 100%; }
 
 /* =================== TOAST =================== */
-#toaster{position:fixed;top:14px;right:14px;display:flex;flex-direction:column;gap:12px;z-index:11000;pointer-events:none}
+#toaster{position:fixed;top:14px;right:14px;display:flex;flex-direction:column;gap:12px;z-index:12000;pointer-events:none}
    #toaster .toast{pointer-events:auto}
 
 .toast{

--- a/app.js
+++ b/app.js
@@ -545,7 +545,14 @@ const DEFAULT_SMS_TEMPLATES = {
 
   /* ========= Toast ========= */
   function toast(msg, kind='ok', ms=1800){
-    const host = document.getElementById('toaster') || (()=>{ const d=document.createElement('div'); d.id='toaster'; document.body.appendChild(d); return d; })();
+    let host = document.getElementById('toaster');
+    if(!host){
+      host = document.createElement('div');
+      host.id = 'toaster';
+    }
+    // Ensure the toaster is the last element so it overlays open modals
+    document.body.appendChild(host);
+
     const el = document.createElement('div');
     el.className = 'toast ' + (kind==='err'?'err':'ok');
     el.innerHTML = (kind==='err' ? '⚠️' : '✅') + ' ' + (msg||'');


### PR DESCRIPTION
## Summary
- Keep the toaster element at the top of `<body>` so toast messages appear above open modals
- Raise toaster z-index to guarantee it stacks above modal content

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aacaf5fec0832690f0a7da023a5d69