### PR TITLE
Reset settings modal scroll after DOM updates

### DIFF
--- a/app.js
+++ b/app.js
@@ -2171,8 +2171,12 @@ function initMorePanel(){
       panes.forEach(p=>p.classList.remove('active'));
       btn.classList.add('primary');
       modal.querySelector('#tab_'+btn.dataset.tab).classList.add('active');
-      scrollArea.scrollTop = 0;
-      modal.scrollTop = 0;
+      requestAnimationFrame(()=>{
+        requestAnimationFrame(()=>{
+          scrollArea.scrollTop = 0;
+          modal.scrollTop = 0;
+        });
+      });
     });
   });
   // --- Make SMS template textareas bigger + auto-grow ---
@@ -2242,6 +2246,10 @@ function loadIntoUI(){
     modal.querySelectorAll('textarea[id^="tpl_unr_"], textarea[id^="tpl_rch_"]').forEach(t=>{
       t.style.height = 'auto';
       t.style.height = (t.scrollHeight + 2) + 'px';
+    });
+    requestAnimationFrame(()=>{
+      scrollArea.scrollTop = 0;
+      modal.scrollTop = 0;
     });
   });
 }


### PR DESCRIPTION
## Summary
- Keep settings modal tab content at the top after auto-growing textareas
- Defer tab switch scroll resets to a nested animation frame for consistent positioning

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aaee80627c8326ba81f9c8f5b6db96