### PR TITLE
Ensure Unreached SMS tab windows are visible

### DIFF
--- a/app.css
+++ b/app.css
@@ -821,11 +821,11 @@ body.light #toolRail .tool{
   margin:10px 0;
   position:sticky;
   top:0;
-  z-index:1;
+  z-index:50; /* stay above tab content */
   background:var(--panel);
 }
 #moreModal .tabs button{ flex:1; }
-#moreModal .tab-pane{ display:none; }
+#moreModal .tab-pane{ display:none; position:relative; z-index:0; }
 #moreModal .tab-pane.active{ display:block; }
 #moreModal .more-actions{
   background:var(--panel);

--- a/app.js
+++ b/app.js
@@ -2171,6 +2171,10 @@ function initMorePanel(){
       panes.forEach(p=>p.classList.remove('active'));
       btn.classList.add('primary');
       modal.querySelector('#tab_'+btn.dataset.tab).classList.add('active');
+      // Close any open dropdowns/datalists before switching panes
+      if (document.activeElement instanceof HTMLElement) {
+        document.activeElement.blur();
+      }
       requestAnimationFrame(()=>{
         scrollArea.scrollTop = 0;
         modal.scrollTop = 0;


### PR DESCRIPTION
## Summary
- Keep modal tabs above SMS template content with higher z-index
- Blur focused inputs when switching tabs to avoid lingering dropdowns

## Testing
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aafa8e515083269e9be65c449bb4cc