### PR TITLE
style: refine more modal tab bar

### DIFF
--- a/app.css
+++ b/app.css
@@ -818,11 +818,13 @@ body.light #toolRail .tool{
   padding:0 20px 10px;
 }
 #moreModal .tabs{
-  margin:10px 0;
+  margin:0 0 10px;
+  padding:4px;
   position:sticky;
   top:0;
   z-index:50; /* stay above tab content */
-  background:var(--panel);
+  background:var(--chip);
+  border-bottom:1px solid var(--line);
 }
 #moreModal .tabs button{ flex:1; }
 #moreModal .tab-pane{ display:none; position:relative; z-index:0; }


### PR DESCRIPTION
## Summary
- Adjust more modal tab bar styling for clearer contrast
- Leverage existing segmented control rules to keep tabs readable in dark and light themes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0508f87c8326bd25bf5b010dca10