### PR TITLE
style: lower more modal tabs z-index

### DIFF
--- a/app.css
+++ b/app.css
@@ -821,7 +821,7 @@ body.light #toolRail .tool{
   padding:4px;
   position:sticky;
   top:0;
-  z-index:50; /* stay above tab content */
+  z-index:2; /* stay above tab content but below popups */
   background:var(--chip);
   border-bottom:1px solid var(--line);
   display:flex;


### PR DESCRIPTION
## Summary
- lower `#moreModal .tabs` z-index so popup windows aren't obscured

## Testing
- `node -e "console.log('no tests to run')"`


------
https://chatgpt.com/codex/tasks/task_e_68ab09cf009883268b852b963f102a53