### PR TITLE
Fix tab bar height jump in more modal

### DIFF
--- a/app.css
+++ b/app.css
@@ -826,8 +826,14 @@ body.light #toolRail .tool{
   border-bottom:1px solid var(--line);
   display:flex;
   gap:4px;
+  align-items:center;
+  flex:none;
 }
-#moreModal .tabs button{ flex:1; }
+#moreModal .tabs button{
+  flex:1;
+  height:34px;
+  line-height:34px;
+}
 #moreModal .tab-content{
   flex:1;
   overflow:auto;


### PR DESCRIPTION
## Summary
- keep #moreModal tab bar from shrinking when tab content scrolls
- set explicit height and line-height on modal tabs buttons

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab20e513bc8326b359e07ccb011392