### PR TITLE
Remove local time override control

### DIFF
--- a/app.css
+++ b/app.css
@@ -104,20 +104,8 @@ header .wrap{ padding-block:10px; }
 h1{font-size:28px; margin:0 0 4px; font-weight:800; line-height:1.1}
 .sub{color:var(--muted); font-size:13.5px}
 
-.dev-time-ctrl{
-  display:flex;
-  align-items:center;
-  gap:6px;
-}
-.dev-time-ctrl input,
-.dev-time-ctrl button{
-  height:28px;
-  padding:4px 8px;
-}
-.dev-time-ctrl .tiny{white-space:nowrap;}
-
 /* =================== CARDS / CONTROLS =================== */
-.card{background:var(--panel); border:1px solid var(--line); border-radius:20px; box-shadow:var(--sh-1);} 
+.card{background:var(--panel); border:1px solid var(--line); border-radius:20px; box-shadow:var(--sh-1);}
 .card .hd{
   padding:14px 16px; border-bottom:1px solid var(--line);
   display:flex; align-items:center; gap:10px; flex-wrap:wrap;
@@ -944,16 +932,3 @@ body.drawer-overlap #app {
 /* Local time colouring */
 .local-time.lt-red{ color: var(--danger); }
 .local-time.lt-green{ color: var(--accent-2); }
-
-#devTimeCtrl{
-  position:fixed;
-  top:calc(var(--header-h) + 8px);
-  left:4px;
-  z-index:1000;
-  display:flex;
-  gap:4px;
-  align-items:center;
-}
-#devTimeCtrl input{
-  max-width:180px;
-}

--- a/app.js
+++ b/app.js
@@ -47,12 +47,7 @@ const $  = sel => document.querySelector(sel);
 const $$ = sel => Array.from(document.querySelectorAll(sel));
 
 function getNow(){
-  let base;
-  if (state?.settings?.timeOverride){
-    base = new Date(state.settings.timeOverride);
-  } else {
-    base = new Date();
-  }
+  const base = new Date();
   const tz = state?.settings?.officeTz;
   if (tz){
     try{
@@ -854,8 +849,7 @@ function defaults(){
       agent: { name:'', phone:'' },
       smsTemplates: JSON.parse(JSON.stringify(DEFAULT_SMS_TEMPLATES)),
       officeCity: '',
-      officeTz: '',
-      timeOverride: ''
+      officeTz: ''
     }
   };
 }
@@ -877,7 +871,6 @@ s.settings.smsTemplates.reached = {
 };
 if (!s.settings.officeCity) s.settings.officeCity = '';
 if (!s.settings.officeTz) s.settings.officeTz = '';
-if (!s.settings.timeOverride) s.settings.timeOverride = '';
 
       return s;
     }catch(e){ return defaults(); }
@@ -3025,38 +3018,6 @@ function centerMainCards(){
 
   customers?.classList.add('centered');
   agenda?.classList.add('centered');
-}
-
-function initTimeControl(){
-  const input = document.getElementById('timeOverride');
-  const reset = document.getElementById('timeOverrideReset');
-  const localTimeEl = document.getElementById('localTime');
-  if(localTimeEl){
-    try{
-      const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
-      localTimeEl.setAttribute('data-tz', tz);
-    }catch(_){ /* ignore */ }
-  }
-  if(!input || !reset) return;
-  if(state.settings.timeOverride){
-    input.value = state.settings.timeOverride;
-  }
-  input.addEventListener('change', ()=>{
-    state.settings.timeOverride = input.value;
-    save();
-    updateLocalTimes();
-  });
-  reset.addEventListener('click', ()=>{
-    input.value='';
-    state.settings.timeOverride='';
-    save();
-    updateLocalTimes();
-  });
-}
-
-
-
-
   /* ========= Notifications boot ========= */
   initNotificationsUI();
   startNotificationTicker();
@@ -3074,8 +3035,7 @@ function bootstrap(){
   initCalendarDrawer();
   initNamesDrawer();
   initSideTabs();
-initMorePanel();
-  initTimeControl();
+  initMorePanel();
   afterLayout();
   centerMainCards();
   updateLocalTimes();

--- a/index.html
+++ b/index.html
@@ -28,11 +28,6 @@
 
   <header>
     <div class="wrap" style="display:flex; align-items:center; gap:12px">
-      <div id="devTimeCtrl" class="dev-time-ctrl">
-        <span class="tiny">Local: <span id="localTime" class="mono local-time"></span></span>
-        <input type="datetime-local" id="timeOverride" title="Override local time" />
-        <button id="timeOverrideReset" class="tiny">Reset</button>
-      </div>
       <div>
         <h1>Follow-Up CRM LAB!</h1>
         <div class="sub">Local-only CRM (HTML + CSS + JS) for <b>Unreached</b> and <b>Reached</b> customers, agenda & calendar—no servers or logins.</div>


### PR DESCRIPTION
## Summary
- remove header dev time override widget and related styles
- simplify time calculations to always use current time
- drop time override state and initialization logic

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68ab210ef21c8326967cb3762d5088ef