### PR TITLE
Ensure agenda date picker respects header layering

### DIFF
--- a/app.css
+++ b/app.css
@@ -459,7 +459,9 @@ body.light .group-hd .label{ font-weight:700; }
 #agendaDate.glow{ animation:agenda-date-flash .95s ease }
 #agendaDate{
   position:relative;
-  z-index:10060; /* keep native picker above the sticky header */
+}
+#agendaDate:focus{
+  z-index:10060; /* keep native picker above the sticky header when active */
 }
 @keyframes agenda-date-flash{ 0%{box-shadow:0 0 0 0 var(--accent);} 50%{box-shadow:0 0 0 4px var(--accent);} 100%{box-shadow:0 0 0 0 var(--accent);} }
 #calTitle{ display:block; text-align:center; }


### PR DESCRIPTION
## Summary
- keep agenda date picker behind header until focused

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68accbb30f84832681ef4dba1ee7af82