### PR TITLE
Add bottom-right back-to-top agenda button

### DIFF
--- a/app.css
+++ b/app.css
@@ -964,3 +964,23 @@ body.drawer-overlap #app {
 /* Local time colouring */
 .local-time.lt-red{ color: var(--danger); }
 .local-time.lt-green{ color: var(--accent-2); }
+
+/* Back to top button */
+#backToTop{
+  position:fixed;
+  bottom:20px;
+  right:20px;
+  width:40px;
+  height:40px;
+  border-radius:50%;
+  background:var(--accent);
+  color:#fff;
+  border:none;
+  display:flex;
+  align-items:center;
+  justify-content:center;
+  cursor:pointer;
+  box-shadow:var(--sh-1);
+  z-index:10;
+}
+#backToTop:hover{ opacity:.9; }

--- a/app.js
+++ b/app.js
@@ -3322,6 +3322,9 @@ function bootstrap(){
   centerMainCards();
   updateLocalTimes();
 
+    document.getElementById('backToTop')
+      ?.addEventListener('click', scrollAgendaIntoView);
+
     $('#testConfettiBtn')?.addEventListener('click', launchConfetti);
 
     initNotificationsUI();

--- a/index.html
+++ b/index.html
@@ -427,5 +427,6 @@
 
   <!-- Toast container -->
   <div id="toaster" aria-live="polite"></div>
+  <button id="backToTop" class="back-top" type="button" title="Back to agenda">↑</button>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add floating back-to-top arrow that scrolls the page so the Agenda sits just below the header.
- Style the button for visibility in both themes.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c46191fbc0832699040b17e62c1421