### PR TITLE
Add backup import/export workflow to More modal

### DIFF
--- a/app.css
+++ b/app.css
@@ -860,6 +860,35 @@ body.light #toolRail .tool{
   border-top:1px solid var(--line);
   padding:10px 20px;
 }
+#moreModal .backup-actions{
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-top:8px;
+}
+#moreModal .backup-actions button{
+  flex:0 0 auto;
+}
+#moreModal .backup-actions.backup-actions--inline{
+  margin-top:6px;
+}
+#moreModal #backupText{
+  width:100%;
+  min-height:120px;
+  font-family:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+  font-size:12px;
+  line-height:1.4;
+}
+#moreModal .backup-status{
+  min-height:1em;
+  margin-top:6px;
+}
+#moreModal .backup-status.ok{
+  color:var(--accent);
+}
+#moreModal .backup-status.error{
+  color:#a23b3b;
+}
 @keyframes pop{ from{ opacity:0; transform:translateY(8px) scale(.985) } to{ opacity:1; transform:none } }
 #addCard{ display:none; }
 


### PR DESCRIPTION
## Summary
- add backup and restore controls to the More modal so agents can copy, download, or import full data snapshots
- share a normalization helper for saved state and use it when loading and restoring backups
- style the new backup section to keep the modal layout tidy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d954aafd548326a89d59fbd4a469cc